### PR TITLE
Expose more whisper parameters

### DIFF
--- a/Assets/Samples/2 - Microphone/2 - Microphone.unity
+++ b/Assets/Samples/2 - Microphone/2 - Microphone.unity
@@ -798,7 +798,10 @@ MonoBehaviour:
   language: auto
   translateToEnglish: 0
   strategy: 0
-  noContext: 0
+  noContext: 1
+  singleSegment: 1
+  speedUp: 0
+  audioCtx: 0
 --- !u!1 &637716610
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Samples/2 - Microphone/2 - Microphone.unity
+++ b/Assets/Samples/2 - Microphone/2 - Microphone.unity
@@ -796,6 +796,9 @@ MonoBehaviour:
   modelPath: Whisper/ggml-tiny.bin
   initOnAwake: 1
   language: auto
+  translateToEnglish: 0
+  strategy: 0
+  noContext: 0
 --- !u!1 &637716610
 GameObject:
   m_ObjectHideFlags: 0
@@ -997,6 +1000,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1400360879}
+  - {fileID: 1425433664}
   m_Father: {fileID: 781718532}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1058,7 +1062,7 @@ MonoBehaviour:
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 1920, y: 1080}
   m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0.33
+  m_MatchWidthOrHeight: 0.345
   m_PhysicalUnit: 3
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
@@ -1187,6 +1191,86 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 951242086}
+  m_CullTransparentMesh: 1
+--- !u!1 &994514759
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 994514760}
+  - component: {fileID: 994514762}
+  - component: {fileID: 994514761}
+  m_Layer: 5
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &994514760
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 994514759}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1425433664}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.17822656, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -2.5, y: -0.5}
+  m_SizeDelta: {x: -5, y: -3}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &994514761
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 994514759}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 40
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 3
+    m_MaxSize: 83
+    m_Alignment: 3
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: English Translation
+--- !u!222 &994514762
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 994514759}
   m_CullTransparentMesh: 1
 --- !u!1 &1001182872
 GameObject:
@@ -1356,6 +1440,82 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1010733613}
   m_CullTransparentMesh: 1
+--- !u!1 &1218648887
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1218648888}
+  - component: {fileID: 1218648890}
+  - component: {fileID: 1218648889}
+  m_Layer: 5
+  m_Name: Checkmark
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1218648888
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1218648887}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1395701403}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1218648889
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1218648887}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10901, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1218648890
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1218648887}
+  m_CullTransparentMesh: 1
 --- !u!1 &1314793982
 GameObject:
   m_ObjectHideFlags: 0
@@ -1485,6 +1645,7 @@ MonoBehaviour:
   outputText: {fileID: 203807867}
   timeText: {fileID: 167558892}
   languageDropdown: {fileID: 1400360880}
+  translateToggle: {fileID: 1425433665}
 --- !u!1 &1370179832
 GameObject:
   m_ObjectHideFlags: 0
@@ -1598,6 +1759,83 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1385040773}
+  m_CullTransparentMesh: 1
+--- !u!1 &1395701402
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1395701403}
+  - component: {fileID: 1395701405}
+  - component: {fileID: 1395701404}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1395701403
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1395701402}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1218648888}
+  m_Father: {fileID: 1425433664}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0.17822656, y: 1}
+  m_AnchoredPosition: {x: 5, y: 0}
+  m_SizeDelta: {x: -10, y: -10}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!114 &1395701404
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1395701402}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1395701405
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1395701402}
   m_CullTransparentMesh: 1
 --- !u!1 &1400360878
 GameObject:
@@ -1742,6 +1980,93 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1400360878}
   m_CullTransparentMesh: 1
+--- !u!1 &1425433663
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1425433664}
+  - component: {fileID: 1425433665}
+  m_Layer: 5
+  m_Name: EnglishTranslation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1425433664
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1425433663}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1395701403}
+  - {fileID: 994514760}
+  m_Father: {fileID: 735179748}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -19.914062, y: -184}
+  m_SizeDelta: {x: -119.46, y: 96.3578}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!114 &1425433665
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1425433663}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9085046f02f69544eb97fd06b6048fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1395701404}
+  toggleTransition: 1
+  graphic: {fileID: 1218648889}
+  m_Group: {fileID: 0}
+  onValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_IsOn: 1
 --- !u!1 &1431014843
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Samples/2 - Microphone/MicrophoneDemo.cs
+++ b/Assets/Samples/2 - Microphone/MicrophoneDemo.cs
@@ -20,6 +20,7 @@ namespace Whisper.Samples
         public Text outputText;
         public Text timeText;
         public Dropdown languageDropdown;
+        public Toggle translateToggle;
 
         private float _recordStart;
         private bool _isRecording;
@@ -28,7 +29,13 @@ namespace Whisper.Samples
         private void Awake()
         {
             button.onClick.AddListener(OnButtonPressed);
+
+            languageDropdown.value = languageDropdown.options
+                .FindIndex((op) => op.text == whisper.language);
             languageDropdown.onValueChanged.AddListener(OnLanguageChanged);
+
+            translateToggle.isOn = whisper.translateToEnglish;
+            translateToggle.onValueChanged.AddListener(OnTranslateChanged);
         }
 
         private void Update()
@@ -55,7 +62,12 @@ namespace Whisper.Samples
         private void OnLanguageChanged(int ind)
         {
             var opt = languageDropdown.options[ind];
-            whisper.SetLanguage(opt.text);
+            whisper.language = opt.text;
+        }
+        
+        private void OnTranslateChanged(bool translate)
+        {
+            whisper.translateToEnglish = translate;
         }
 
         public void StartRecord()

--- a/Packages/com.whisper.unity/Runtime/Native/WhisperNativeParams.cs
+++ b/Packages/com.whisper.unity/Runtime/Native/WhisperNativeParams.cs
@@ -21,7 +21,7 @@ namespace Whisper.Native
     {
         public WhisperSamplingStrategy strategy;
 
-        int n_threads;
+        public int n_threads;
         int n_max_text_ctx; // max tokens to use from past text as prompt for the decoder
         int offset_ms; // start offset in ms
         int duration_ms; // audio duration to process in ms

--- a/Packages/com.whisper.unity/Runtime/Native/WhisperNativeParams.cs
+++ b/Packages/com.whisper.unity/Runtime/Native/WhisperNativeParams.cs
@@ -14,8 +14,12 @@ namespace Whisper.Native
         WHISPER_SAMPLING_BEAM_SEARCH = 1, // similar to OpenAI's BeamSearchDecoder
     };
 
-    // This is direct copy of C++ struct
-    // Do not change or add any fields without changing it in whisper.cpp
+
+    /// <summary>
+    /// This is direct copy of C++ struct.
+    /// Do not change or add any fields without changing it in whisper.cpp.
+    /// Do not change it in runtime directly, use <see cref="WhisperParams"/>.
+    /// </summary>
     [StructLayout(LayoutKind.Sequential)]
     public unsafe struct WhisperNativeParams
     {
@@ -44,7 +48,7 @@ namespace Whisper.Native
 
         // [EXPERIMENTAL] speed-up techniques
         // note: these can significantly reduce the quality of the output
-        [MarshalAs(UnmanagedType.U1)] bool speed_up; // speed-up the audio by 2x using Phase Vocoder
+        [MarshalAs(UnmanagedType.U1)] public bool speed_up; // speed-up the audio by 2x using Phase Vocoder
         int audio_ctx; // overwrite the audio context size (0 = use default)
 
         // tokens to provide to the whisper decoder as initial prompt

--- a/Packages/com.whisper.unity/Runtime/Native/WhisperNativeParams.cs
+++ b/Packages/com.whisper.unity/Runtime/Native/WhisperNativeParams.cs
@@ -26,21 +26,13 @@ namespace Whisper.Native
         public int offset_ms; // start offset in ms
         public int duration_ms; // audio duration to process in ms
 
-        [MarshalAs(UnmanagedType.U1)] 
-        public bool translate;
-
-        [MarshalAs(UnmanagedType.U1)]
-        public bool no_context; // do not use past transcription (if any) as initial prompt for the decoder
-
-        [MarshalAs(UnmanagedType.U1)] bool single_segment; // force single segment output (useful for streaming)
-        [MarshalAs(UnmanagedType.U1)] bool print_special; // print special tokens (e.g. <SOT>, <EOT>, <BEG>, etc.)
-        [MarshalAs(UnmanagedType.U1)] bool print_progress; // print progress information
-
-        [MarshalAs(UnmanagedType.U1)]
-        bool print_realtime; // print results from within whisper.cpp (avoid it, use callback instead)
-
-        [MarshalAs(UnmanagedType.U1)]
-        bool print_timestamps; // print timestamps for each text segment when printing realtime
+        [MarshalAs(UnmanagedType.U1)] public bool translate;
+        [MarshalAs(UnmanagedType.U1)] public bool no_context; // do not use past transcription (if any) as initial prompt for the decoder
+        [MarshalAs(UnmanagedType.U1)] public bool single_segment; // force single segment output (useful for streaming)
+        [MarshalAs(UnmanagedType.U1)] public bool print_special; // print special tokens (e.g. <SOT>, <EOT>, <BEG>, etc.)
+        [MarshalAs(UnmanagedType.U1)] public bool print_progress; // print progress information
+        [MarshalAs(UnmanagedType.U1)] public bool print_realtime; // print results from within whisper.cpp (avoid it, use callback instead)
+        [MarshalAs(UnmanagedType.U1)] public bool print_timestamps; // print timestamps for each text segment when printing realtime
 
         // [EXPERIMENTAL] token-level timestamps
         [MarshalAs(UnmanagedType.U1)] bool token_timestamps; // enable token-level timestamps

--- a/Packages/com.whisper.unity/Runtime/Native/WhisperNativeParams.cs
+++ b/Packages/com.whisper.unity/Runtime/Native/WhisperNativeParams.cs
@@ -22,11 +22,12 @@ namespace Whisper.Native
         public WhisperSamplingStrategy strategy;
 
         public int n_threads;
-        int n_max_text_ctx; // max tokens to use from past text as prompt for the decoder
-        int offset_ms; // start offset in ms
-        int duration_ms; // audio duration to process in ms
+        public int n_max_text_ctx; // max tokens to use from past text as prompt for the decoder
+        public int offset_ms; // start offset in ms
+        public int duration_ms; // audio duration to process in ms
 
-        [MarshalAs(UnmanagedType.U1)] bool translate;
+        [MarshalAs(UnmanagedType.U1)] 
+        public bool translate;
 
         [MarshalAs(UnmanagedType.U1)]
         public bool no_context; // do not use past transcription (if any) as initial prompt for the decoder

--- a/Packages/com.whisper.unity/Runtime/Native/WhisperNativeParams.cs
+++ b/Packages/com.whisper.unity/Runtime/Native/WhisperNativeParams.cs
@@ -49,7 +49,7 @@ namespace Whisper.Native
         // [EXPERIMENTAL] speed-up techniques
         // note: these can significantly reduce the quality of the output
         [MarshalAs(UnmanagedType.U1)] public bool speed_up; // speed-up the audio by 2x using Phase Vocoder
-        int audio_ctx; // overwrite the audio context size (0 = use default)
+        public int audio_ctx; // overwrite the audio context size (0 = use default)
 
         // tokens to provide to the whisper decoder as initial prompt
         // these are prepended to any existing text context from a previous call

--- a/Packages/com.whisper.unity/Runtime/WhisperManager.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using UnityEngine;
+using Whisper.Native;
 
 namespace Whisper
 {
@@ -15,8 +16,12 @@ namespace Whisper
         [Tooltip("Should model weights be loaded on awake?")]
         private bool initOnAwake = true;
     
+        [Header("Parameters")]
         [SerializeField]
-        [Tooltip("Output text language. Use \"auto\" for auto-detection.")]
+        private WhisperSamplingStrategy strategy = WhisperSamplingStrategy.WHISPER_SAMPLING_GREEDY;
+        
+        [SerializeField]
+        [Tooltip("Output text language. Use empty or \"auto\" for auto-detection.")]
         private string language = "en";
         
         private WhisperWrapper _whisper;
@@ -57,7 +62,7 @@ namespace Whisper
                 var path = Path.Combine(Application.streamingAssetsPath, modelPath);
                 _whisper = await WhisperWrapper.InitFromFileAsync(path);
                 
-                _params = WhisperParams.GetDefaultParams();
+                _params = WhisperParams.GetDefaultParams(strategy);
                 _params.Language = language;
             }
             catch (Exception e)

--- a/Packages/com.whisper.unity/Runtime/WhisperManager.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperManager.cs
@@ -17,19 +17,17 @@ namespace Whisper
         private bool initOnAwake = true;
         
         [Header("Language")]
-        [SerializeField]
         [Tooltip("Output text language. Use empty or \"auto\" for auto-detection.")]
-        private string language = "en";
-        [SerializeField]
+        public string language = "en";
         [Tooltip("Force output text to English translation. Improves translation quality.")]
-        private bool translateToEnglish;
+        public bool translateToEnglish;
         
         [Header("Advanced settings")]
         [SerializeField]
         private WhisperSamplingStrategy strategy = WhisperSamplingStrategy.WHISPER_SAMPLING_GREEDY;
         [SerializeField]
         [Tooltip("Do not use past transcription (if any) as initial prompt for the decoder.")]
-        private bool noContext;
+        public bool noContext;
         
         private WhisperWrapper _whisper;
         private WhisperParams _params;
@@ -37,7 +35,7 @@ namespace Whisper
         public bool IsLoaded => _whisper != null;
         public bool IsLoading { get; private set; }
         public bool IsBusy { get; private set; }
-        
+
         private async void Awake()
         {
             if (!initOnAwake)
@@ -68,11 +66,7 @@ namespace Whisper
             {
                 var path = Path.Combine(Application.streamingAssetsPath, modelPath);
                 _whisper = await WhisperWrapper.InitFromFileAsync(path);
-                
                 _params = WhisperParams.GetDefaultParams(strategy);
-                _params.Language = language;
-                _params.Translate = translateToEnglish;
-                _params.NoContext = noContext;
             }
             catch (Exception e)
             {
@@ -90,6 +84,7 @@ namespace Whisper
             if (!isLoaded)
                 return null;
             
+            UpdateParams();
             var res = await _whisper.GetTextAsync(clip, _params);
             return res;
         }
@@ -103,18 +98,17 @@ namespace Whisper
             var isLoaded = await CheckIfLoaded();
             if (!isLoaded)
                 return null;
-            
+
+            UpdateParams();
             var res = await _whisper.GetTextAsync(samples, frequency, channels, _params);
             return res;
         }
-        
-        /// <summary>
-        /// Choose text output language.
-        /// </summary>
-        public void SetLanguage(string newLanguage)
+
+        private void UpdateParams()
         {
-            language = newLanguage;
-            _params.Language = newLanguage;
+            _params.Language = language;
+            _params.Translate = translateToEnglish;
+            _params.NoContext = noContext;
         }
 
         private async Task<bool> CheckIfLoaded()

--- a/Packages/com.whisper.unity/Runtime/WhisperManager.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperManager.cs
@@ -25,9 +25,21 @@ namespace Whisper
         [Header("Advanced settings")]
         [SerializeField]
         private WhisperSamplingStrategy strategy = WhisperSamplingStrategy.WHISPER_SAMPLING_GREEDY;
-        [SerializeField]
+
         [Tooltip("Do not use past transcription (if any) as initial prompt for the decoder.")]
-        public bool noContext;
+        public bool noContext = true;
+        
+        [Tooltip("Force single segment output (useful for streaming).")]
+        public bool singleSegment = true;
+        
+        [Header("Experimental settings")]
+        [Tooltip("[EXPERIMENTAL] Speed-up the audio by 2x using Phase Vocoder. " +
+                 "These can significantly reduce the quality of the output.")]
+        public bool speedUp = false;
+        
+        [Tooltip("[EXPERIMENTAL] Overwrite the audio context size (0 = use default). " +
+                 "These can significantly reduce the quality of the output.")]
+        public int audioCtx;
         
         private WhisperWrapper _whisper;
         private WhisperParams _params;
@@ -109,6 +121,9 @@ namespace Whisper
             _params.Language = language;
             _params.Translate = translateToEnglish;
             _params.NoContext = noContext;
+            _params.SingleSegment = singleSegment;
+            _params.SpeedUp = speedUp;
+            _params.AudioCtx = audioCtx;
         }
 
         private async Task<bool> CheckIfLoaded()

--- a/Packages/com.whisper.unity/Runtime/WhisperManager.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperManager.cs
@@ -15,14 +15,21 @@ namespace Whisper
         [SerializeField]
         [Tooltip("Should model weights be loaded on awake?")]
         private bool initOnAwake = true;
-    
-        [Header("Parameters")]
-        [SerializeField]
-        private WhisperSamplingStrategy strategy = WhisperSamplingStrategy.WHISPER_SAMPLING_GREEDY;
         
+        [Header("Language")]
         [SerializeField]
         [Tooltip("Output text language. Use empty or \"auto\" for auto-detection.")]
         private string language = "en";
+        [SerializeField]
+        [Tooltip("Force output text to English translation. Improves translation quality.")]
+        private bool translateToEnglish;
+        
+        [Header("Advanced settings")]
+        [SerializeField]
+        private WhisperSamplingStrategy strategy = WhisperSamplingStrategy.WHISPER_SAMPLING_GREEDY;
+        [SerializeField]
+        [Tooltip("Do not use past transcription (if any) as initial prompt for the decoder.")]
+        private bool noContext;
         
         private WhisperWrapper _whisper;
         private WhisperParams _params;
@@ -64,6 +71,8 @@ namespace Whisper
                 
                 _params = WhisperParams.GetDefaultParams(strategy);
                 _params.Language = language;
+                _params.Translate = translateToEnglish;
+                _params.NoContext = noContext;
             }
             catch (Exception e)
             {

--- a/Packages/com.whisper.unity/Runtime/WhisperParams.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperParams.cs
@@ -195,6 +195,30 @@ namespace Whisper
          
          #endregion
 
+         #region Speed Up
+
+         /// <summary>
+         /// [EXPERIMENTAL] Speed-up the audio by 2x using Phase Vocoder.
+         /// These can significantly reduce the quality of the output.
+         /// </summary>
+         public bool SpeedUp
+         {
+             get => _param.speed_up;
+             set => _param.speed_up = value;
+         }
+
+         /// <summary>
+         /// [EXPERIMENTAL] Overwrite the audio context size (0 = use default).
+         /// These can significantly reduce the quality of the output.
+         /// </summary>
+         public int AudioCtx
+         {
+             get => _param.audio_ctx;
+             set => _param.audio_ctx = value;
+         }
+
+         #endregion
+         
          private void FreeLanguageString()
          {
              // if C# allocated new string before - clear it

--- a/Packages/com.whisper.unity/Runtime/WhisperParams.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperParams.cs
@@ -176,6 +176,9 @@ namespace Whisper
              get => _languageManaged;
              set
              {
+                 if (_languageManaged == value)
+                     return;
+                 
                  _languageManaged = value;
                  unsafe
                  {

--- a/Packages/com.whisper.unity/Runtime/WhisperParams.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperParams.cs
@@ -23,6 +23,20 @@ namespace Whisper
              get => _param.strategy;
              set => _param.strategy = value;
          }
+
+         /// <summary>
+         /// Count of threads (n_threads), should be >= 1.
+         /// </summary>
+         public int ThreadsCount
+         {
+             get => _param.n_threads;
+             set
+             {
+                 if (value < 1)
+                     throw new ArgumentException("Number of threads should be bigger or equal one.");
+                 _param.n_threads = value;
+             }
+         }
      
          /// <summary>
          /// Output text language code (ISO 639-1). For example "en", "es" or "de".

--- a/Packages/com.whisper.unity/Runtime/WhisperParams.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperParams.cs
@@ -11,6 +11,25 @@ namespace Whisper
          private string _languageManaged;
          private IntPtr _languagePtr = IntPtr.Zero;
          
+         private unsafe WhisperParams(WhisperNativeParams param)
+         {
+             _param = param;
+     
+             // copy language string to managed memory
+             var strPtr = new IntPtr(param.language);
+             _languageManaged = Marshal.PtrToStringAnsi(strPtr);
+         }
+     
+         ~WhisperParams()
+         {
+             FreeLanguageString();
+         }
+         
+        #region Parameters
+        
+        /// <summary>
+        /// Native C++ struct parameters. To change use setters.
+        /// </summary>
          public WhisperNativeParams NativeParams => _param;
          
          /// <summary>
@@ -37,6 +56,43 @@ namespace Whisper
                  _param.n_threads = value;
              }
          }
+
+         /// <summary>
+         /// Max tokens to use from past text as prompt for the decoder.
+         /// </summary>
+         public int MaxTextContextCount
+         {
+             get => _param.n_max_text_ctx;
+             set => _param.n_max_text_ctx = value;
+         }
+
+         /// <summary>
+         /// Start audio offset in ms.
+         /// </summary>
+         public int OffsetMs
+         {
+             get => _param.offset_ms;
+             set => _param.offset_ms = value;
+         }
+
+         /// <summary>
+         /// Audio duration to process in ms.
+         /// </summary>
+         // TODO: doesn't work correctly
+         public int DurationMs
+         {
+             get => _param.duration_ms;
+             set => _param.duration_ms = value;
+         }
+         
+         /// <summary>
+         /// Translate from source language to English.
+         /// </summary>
+         public bool Translate
+         {
+             get => _param.translate;
+             set => _param.translate = value;
+         }
      
          /// <summary>
          /// Output text language code (ISO 639-1). For example "en", "es" or "de".
@@ -60,20 +116,9 @@ namespace Whisper
                  }
              }
          }
+         
+         #endregion
 
-         private unsafe WhisperParams(WhisperNativeParams param)
-         {
-             _param = param;
-     
-             // copy language string to managed memory
-             var strPtr = new IntPtr(param.language);
-             _languageManaged = Marshal.PtrToStringAnsi(strPtr);
-         }
-     
-         ~WhisperParams()
-         {
-             FreeLanguageString();
-         }
 
          private void FreeLanguageString()
          {

--- a/Packages/com.whisper.unity/Runtime/WhisperParams.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperParams.cs
@@ -78,7 +78,7 @@ namespace Whisper
          /// <summary>
          /// Audio duration to process in ms.
          /// </summary>
-         // TODO: doesn't work correctly
+         // TODO: doesn't work correctly for some reason
          public int DurationMs
          {
              get => _param.duration_ms;
@@ -92,6 +92,66 @@ namespace Whisper
          {
              get => _param.translate;
              set => _param.translate = value;
+         }
+
+         /// <summary>
+         /// Do not use past transcription (if any) as initial prompt for the decoder.
+         /// </summary>
+         public bool NoContext
+         {
+             get => _param.no_context;
+             set => _param.no_context = value;
+         }
+
+         /// <summary>
+         /// Force single segment output (useful for streaming).
+         /// </summary>
+         public bool SingleSegment
+         {
+             get => _param.single_segment;
+             set => _param.single_segment = value;
+         }
+         
+         /// <summary>
+         /// Print special tokens (e.g. SOT, EOT, BEG, etc.)
+         /// </summary>
+         public bool PrintSpecial
+         {
+             get => _param.print_special;
+             set => _param.print_special = value;
+         }
+
+         /// <summary>
+         /// Print progress information in C++ log.
+         /// It won't be shown in Unity console, but visible in Unity log file.
+         /// <a href="https://docs.unity3d.com/Manual/LogFiles.html">Log file location.</a>
+         /// </summary>
+         public bool PrintProgress
+         {
+             get => _param.print_progress;
+             set => _param.print_progress = value;
+         }
+
+         /// <summary>
+         /// Print results from within whisper.cpp in C++ log (avoid it, use callback instead).
+         /// It won't be shown in Unity console, but visible in Unity log file.
+         /// <a href="https://docs.unity3d.com/Manual/LogFiles.html">Log file location.</a>
+         /// </summary>
+         public bool PrintRealtime
+         {
+             get => _param.print_realtime;
+             set => _param.print_realtime = value;
+         }
+         
+         /// <summary>
+         /// Print timestamps for each text segment when printing realtime in C++ log.
+         /// It won't be shown in Unity console, but visible in Unity log file.
+         /// <a href="https://docs.unity3d.com/Manual/LogFiles.html">Log file location.</a>
+         /// </summary>
+         public bool PrintTimestamps
+         {
+             get => _param.print_timestamps;
+             set => _param.print_timestamps = value;
          }
      
          /// <summary>

--- a/Packages/com.whisper.unity/Runtime/WhisperParams.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperParams.cs
@@ -12,6 +12,17 @@ namespace Whisper
          private IntPtr _languagePtr = IntPtr.Zero;
          
          public WhisperNativeParams NativeParams => _param;
+         
+         /// <summary>
+         /// Sampling Whisper strategy.
+         /// Greedy tends to be faster, but has lower quality.
+         /// Beam search slower, but higher quality.
+         /// </summary>
+         public WhisperSamplingStrategy Strategy
+         {
+             get => _param.strategy;
+             set => _param.strategy = value;
+         }
      
          /// <summary>
          /// Output text language code (ISO 639-1). For example "en", "es" or "de".
@@ -35,7 +46,7 @@ namespace Whisper
                  }
              }
          }
-         
+
          private unsafe WhisperParams(WhisperNativeParams param)
          {
              _param = param;


### PR DESCRIPTION
Adds more getter and setters for whisper parameters. Most interesting are:
- `ThreadsCount` - limit threads count used by whisper
- `Translate` - inference whisper in translation to English mode. Improves English translation.
- `SingleSegment` - output text in single segment
- `SpeedUp` and `AudioCtx` - experemental  settings to improve performance by loosing quality

Also update `WhisperManager` inspector to reflect some parameters.
<img width="585" alt="Снимок экрана 2023-04-08 в 11 18 17" src="https://user-images.githubusercontent.com/6161335/230713833-f5d7337f-0987-4514-8049-fcc5440460b2.png">
