### PR TITLE
Faster Android inference

### DIFF
--- a/Packages/com.whisper.unity/Runtime/WhisperParams.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperParams.cs
@@ -243,6 +243,12 @@ namespace Whisper
                  PrintRealtime = false,
                  PrintTimestamps = false
              };
+
+             // for some reason on android one thread works
+             // 10x faster than multithreading
+#if UNITY_ANDROID && !UNITY_EDITOR
+             param.ThreadsCount = 1;
+#endif
              return param;
          }
      }   

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is Unity3d bindings for the [whisper.cpp](https://github.com/ggerganov/whis
 - Windows (x86_64)
 - MacOS (Intel and ARM)
 - iOS (Device and Simulator)
-- Android (ARM64, unstable, [see this issue](https://github.com/Macoron/whisper.unity/issues/2))
+- Android (ARM64)
 
 ## Getting started
 Clone this repository and open it as regular Unity project. It comes with examples and tiny multilanguage model weights.


### PR DESCRIPTION
Fixes #2 

For some reason, single thread works 10x faster than multithreading on Android. Now I'm getting about 10 seconds for jfk.wav transcription on my Google Pixel 4. This still very slow comparing to other platforms, but at least comparable with native Android app.