### PR TITLE
Support for Unity 2019.4 and newer 

### DIFF
--- a/Packages/com.whisper.unity/Runtime/Utils/MainThreadDispatcher.cs
+++ b/Packages/com.whisper.unity/Runtime/Utils/MainThreadDispatcher.cs
@@ -10,7 +10,7 @@ namespace Whisper.Utils
     /// </summary>
     public class MainThreadDispatcher
     {
-        private readonly ConcurrentQueue<Task> _actions = new();
+        private readonly ConcurrentQueue<Task> _actions = new ConcurrentQueue<Task>();
 
         /// <summary>
         /// Add action to be executed on main Unity thread.

--- a/Packages/com.whisper.unity/Runtime/WhisperManager.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperManager.cs
@@ -46,7 +46,7 @@ namespace Whisper
 
         private WhisperWrapper _whisper;
         private WhisperParams _params;
-        private readonly MainThreadDispatcher _dispatcher = new();
+        private readonly MainThreadDispatcher _dispatcher = new MainThreadDispatcher();
 
         public bool IsLoaded => _whisper != null;
         public bool IsLoading { get; private set; }

--- a/Packages/com.whisper.unity/Runtime/WhisperWrapper.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperWrapper.cs
@@ -46,7 +46,7 @@ namespace Whisper
 
         private readonly IntPtr _whisperCtx;
         private readonly WhisperNativeParams _params;
-        private readonly object _lock = new();
+        private readonly object _lock = new object();
 
         private WhisperWrapper(IntPtr whisperCtx)
         {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,15 +1,12 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": "1.15.16",
     "com.unity.feature.development": "1.0.1",
     "com.unity.ide.rider": "3.0.14",
     "com.unity.ide.visualstudio": "2.0.15",
     "com.unity.ide.vscode": "1.2.5",
     "com.unity.test-framework": "1.3.4",
-    "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.6.4",
     "com.unity.ugui": "1.0.0",
-    "com.unity.visualscripting": "1.7.6",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",
     "com.unity.modules.animation": "1.0.0",

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,6 +1,5 @@
 {
   "dependencies": {
-    "com.unity.feature.development": "1.0.1",
     "com.unity.ide.rider": "3.0.14",
     "com.unity.ide.visualstudio": "2.0.15",
     "com.unity.ide.vscode": "1.2.5",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,14 +1,5 @@
 {
   "dependencies": {
-    "com.unity.collab-proxy": {
-      "version": "1.15.16",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.services.core": "1.0.1"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.editorcoroutines": {
       "version": "1.0.0",
       "depth": 1,
@@ -62,29 +53,11 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
-    "com.unity.nuget.newtonsoft-json": {
-      "version": "3.0.2",
-      "depth": 2,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
     "com.unity.performance.profile-analyzer": {
       "version": "1.1.1",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.services.core": {
-      "version": "1.3.1",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.modules.unitywebrequest": "1.0.0",
-        "com.unity.nuget.newtonsoft-json": "3.0.2",
-        "com.unity.modules.androidjni": "1.0.0"
-      },
       "url": "https://packages.unity.com"
     },
     "com.unity.settings-manager": {
@@ -115,15 +88,6 @@
       },
       "url": "https://packages.unity.com"
     },
-    "com.unity.textmeshpro": {
-      "version": "3.0.6",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.ugui": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
     "com.unity.timeline": {
       "version": "1.6.4",
       "depth": 0,
@@ -144,16 +108,6 @@
         "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0"
       }
-    },
-    "com.unity.visualscripting": {
-      "version": "1.7.6",
-      "depth": 0,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.ugui": "1.0.0",
-        "com.unity.modules.jsonserialize": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
     },
     "com.whisper.unity": {
       "version": "file:com.whisper.unity",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,32 +1,11 @@
 {
   "dependencies": {
-    "com.unity.editorcoroutines": {
-      "version": "1.0.0",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
     "com.unity.ext.nunit": {
       "version": "2.0.3",
       "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
-    },
-    "com.unity.feature.development": {
-      "version": "1.0.1",
-      "depth": 0,
-      "source": "builtin",
-      "dependencies": {
-        "com.unity.ide.visualstudio": "2.0.15",
-        "com.unity.ide.rider": "3.0.14",
-        "com.unity.ide.vscode": "1.2.5",
-        "com.unity.editorcoroutines": "1.0.0",
-        "com.unity.performance.profile-analyzer": "1.1.1",
-        "com.unity.test-framework": "1.1.31",
-        "com.unity.testtools.codecoverage": "1.0.1"
-      }
     },
     "com.unity.ide.rider": {
       "version": "3.0.14",
@@ -53,20 +32,6 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
-    "com.unity.performance.profile-analyzer": {
-      "version": "1.1.1",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.settings-manager": {
-      "version": "1.0.3",
-      "depth": 2,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://packages.unity.com"
-    },
     "com.unity.test-framework": {
       "version": "1.3.4",
       "depth": 0,
@@ -75,16 +40,6 @@
         "com.unity.ext.nunit": "2.0.3",
         "com.unity.modules.imgui": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
-      },
-      "url": "https://packages.unity.com"
-    },
-    "com.unity.testtools.codecoverage": {
-      "version": "1.0.1",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {
-        "com.unity.test-framework": "1.0.16",
-        "com.unity.settings-manager": "1.0.1"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
Fixes #13

I made syntax more simple and add support for older Unity API (`UnityWebRequest.Result` and `File.ReadAllBytesAsync`). I also deleted some redundant packages from example project.

Now it should be working starting from Unity 2019.4 LTS and newer. Didn't test more earlier versions.