### PR TITLE
Segments timestamp

### DIFF
--- a/Assets/Samples/1 - Audio Clip/AudioClipDemo.cs
+++ b/Assets/Samples/1 - Audio Clip/AudioClipDemo.cs
@@ -11,6 +11,7 @@ namespace Whisper.Samples
         public bool echoSound = true;
         public bool streamSegments = true;
         public bool printLanguage = true;
+        public bool showTimestamps = true;
 
         [Header("UI")]
         public Button button;
@@ -48,12 +49,20 @@ namespace Whisper.Samples
 
             if (printLanguage)
                 text += $"\n\nLanguage: {res.Language}";
-            outputText.text = text;
+            //outputText.text = text;
         }
         
         private void OnNewSegmentHandler(WhisperSegment segment)
         {
-            _buffer += segment.Text;
+            var timestamp = "";
+            if (showTimestamps)
+            {
+                var startStr = segment.Start.ToString(@"mm\:ss\:fff");
+                var stopStr = segment.End.ToString(@"mm\:ss\:fff");
+                timestamp = $"<b>[{startStr}->{stopStr}]</b>";
+            }
+            
+            _buffer += timestamp + segment.Text + "\n";
             outputText.text = _buffer + "...";
         }
     }

--- a/Assets/Samples/1 - Audio Clip/AudioClipDemo.cs
+++ b/Assets/Samples/1 - Audio Clip/AudioClipDemo.cs
@@ -51,9 +51,9 @@ namespace Whisper.Samples
             outputText.text = text;
         }
         
-        private void OnNewSegmentHandler(int index, string text)
+        private void OnNewSegmentHandler(WhisperSegment segment)
         {
-            _buffer += text;
+            _buffer += segment.Text;
             outputText.text = _buffer + "...";
         }
     }

--- a/Assets/Samples/1 - Audio Clip/AudioClipDemo.cs
+++ b/Assets/Samples/1 - Audio Clip/AudioClipDemo.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Diagnostics;
+using System.Text;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -9,9 +11,11 @@ namespace Whisper.Samples
         public WhisperManager manager;
         public AudioClip clip;
         public bool echoSound = true;
+        
+        [Header("Text Output")]
         public bool streamSegments = true;
         public bool printLanguage = true;
-        public bool showTimestamps = true;
+        public bool showTimestamps;
 
         [Header("UI")]
         public Button button;
@@ -25,6 +29,12 @@ namespace Whisper.Samples
             button.onClick.AddListener(ButtonPressed);
             if (streamSegments)
                 manager.OnNewSegment += OnNewSegmentHandler;
+        }
+
+        private void OnDestroy()
+        {
+            if (streamSegments)
+                manager.OnNewSegment -= OnNewSegmentHandler;
         }
 
         public async void ButtonPressed()
@@ -43,28 +53,43 @@ namespace Whisper.Samples
             var time = sw.ElapsedMilliseconds;
             var rate = clip.length / (time * 0.001f);
             timeText.text = $"Time: {time} ms\nRate: {rate:F1}x";
-            
-            var text = res.Result;
-            print(text);
 
+            var text = GetFinalText(res);
             if (printLanguage)
                 text += $"\n\nLanguage: {res.Language}";
-            //outputText.text = text;
+            
+            outputText.text = text;
         }
         
         private void OnNewSegmentHandler(WhisperSegment segment)
         {
-            var timestamp = "";
-            if (showTimestamps)
+            if (!showTimestamps)
             {
-                var startStr = segment.Start.ToString(@"mm\:ss\:fff");
-                var stopStr = segment.End.ToString(@"mm\:ss\:fff");
-                timestamp = $"<b>[{startStr}->{stopStr}]</b>";
+                _buffer += segment.Text;
+                outputText.text = _buffer + "...";
             }
-            
-            _buffer += timestamp + segment.Text + "\n";
-            outputText.text = _buffer + "...";
+            else
+            {
+                _buffer += $"<b>{segment.TimestampToString()}</b>{segment.Text}\n";
+                outputText.text = _buffer;
+            }
         }
+
+        private string GetFinalText(WhisperResult output)
+        {
+            if (!showTimestamps)
+                return output.Result;
+
+            var sb = new StringBuilder();
+            foreach (var seg in output.Segments)
+            {
+                var segment = $"<b>{seg.TimestampToString()}</b>{seg.Text}\n";
+                sb.Append(segment);
+            }
+
+            return sb.ToString();
+        }
+
     }
 }
 

--- a/Assets/Samples/2 - Microphone/MicrophoneDemo.cs
+++ b/Assets/Samples/2 - Microphone/MicrophoneDemo.cs
@@ -82,9 +82,9 @@ namespace Whisper.Samples
             outputText.text = text;
         }
         
-        private void WhisperOnOnNewSegment(int index, string text)
+        private void WhisperOnOnNewSegment(WhisperSegment segment)
         {
-            _buffer += text;
+            _buffer += segment.Text;
             outputText.text = _buffer + "...";
         }
     }

--- a/Packages/com.whisper.unity/Runtime/Native/WhisperNative.cs
+++ b/Packages/com.whisper.unity/Runtime/Native/WhisperNative.cs
@@ -47,6 +47,12 @@ namespace Whisper.Native
         
         [DllImport(LibraryName)]
         public static extern int whisper_is_multilingual(whisper_context_ptr ctx);
+        
+        [DllImport(LibraryName)]
+        public static extern ulong whisper_full_get_segment_t0(whisper_context_ptr ctx, int i_segment);
+        
+        [DllImport(LibraryName)]
+        public static extern ulong whisper_full_get_segment_t1(whisper_context_ptr ctx, int i_segment);
     
         [DllImport(LibraryName)]
         public static extern IntPtr whisper_full_get_segment_text(whisper_context_ptr ctx, int i_segment);

--- a/Packages/com.whisper.unity/Runtime/WhisperManager.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperManager.cs
@@ -163,11 +163,11 @@ namespace Whisper
             return IsLoaded;
         }
         
-        private void OnNewSegmentHandler(int index, string text)
+        private void OnNewSegmentHandler(WhisperSegment segment)
         {
             _dispatcher.Execute(() =>
             {
-                OnNewSegment?.Invoke(index, text);
+                OnNewSegment?.Invoke(segment);
             });
         }
     }

--- a/Packages/com.whisper.unity/Runtime/WhisperResult.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperResult.cs
@@ -6,12 +6,12 @@ namespace Whisper
 {
     public class WhisperResult
     {
-        public readonly List<string> Segments;
+        public readonly List<WhisperSegment> Segments;
         public readonly string Result;
         public readonly int LanguageId;
         public readonly string Language;
 
-        public WhisperResult(List<string> segments, int languageId)
+        public WhisperResult(List<WhisperSegment> segments, int languageId)
         {
             Segments = segments;
             LanguageId = languageId;
@@ -21,14 +21,14 @@ namespace Whisper
             var builder = new StringBuilder();
             foreach (var seg in segments)
             {
-                builder.Append(seg);
+                builder.Append(seg.Text);
             }
             Result = builder.ToString();
         }
     }
 
     /// <summary>
-    /// Segment of whisper audio transcription.
+    /// Single segment of whisper audio transcription.
     /// Can be a few words, a sentence, or even a paragraph.
     /// </summary>
     public class WhisperSegment
@@ -59,6 +59,17 @@ namespace Whisper
             Text = text;
             Start = TimeSpan.FromMilliseconds(start * 10);
             End = TimeSpan.FromMilliseconds(end * 10);
+        }
+
+        /// <summary>
+        /// Write segment start and end timestamps as a human-readable string.
+        /// </summary>
+        public string TimestampToString()
+        {
+            var startStr = Start.ToString(@"mm\:ss\:fff");
+            var stopStr = End.ToString(@"mm\:ss\:fff");
+            var timestamp = $"[{startStr}->{stopStr}]";
+            return timestamp;
         }
     }
 }

--- a/Packages/com.whisper.unity/Runtime/WhisperResult.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperResult.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -26,19 +27,38 @@ namespace Whisper
         }
     }
 
+    /// <summary>
+    /// Segment of whisper audio transcription.
+    /// Can be a few words, a sentence, or even a paragraph.
+    /// </summary>
     public class WhisperSegment
     {
+        /// <summary>
+        /// Segment index in current Whisper context.
+        /// </summary>
         public readonly int Index;
+        
+        /// <summary>
+        /// Combined text of all tokens in this segment.
+        /// </summary>
         public readonly string Text;
-        public readonly ulong Start;
-        public readonly ulong Stop;
+        
+        /// <summary>
+        /// Segment start timestamp based on transcribed audio.
+        /// </summary>
+        public readonly TimeSpan Start;
+        
+        /// <summary>
+        /// Segment end timestamp based on transcribed audio.
+        /// </summary>
+        public readonly TimeSpan End;
 
-        public WhisperSegment(int index, string text, ulong start, ulong stop)
+        public WhisperSegment(int index, string text, ulong start, ulong end)
         {
             Index = index;
             Text = text;
-            Start = start;
-            Stop = stop;
+            Start = TimeSpan.FromMilliseconds(start * 10);
+            End = TimeSpan.FromMilliseconds(end * 10);
         }
     }
 }

--- a/Packages/com.whisper.unity/Runtime/WhisperResult.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperResult.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace Whisper
+{
+    public class WhisperResult
+    {
+        public readonly List<string> Segments;
+        public readonly string Result;
+        public readonly int LanguageId;
+        public readonly string Language;
+
+        public WhisperResult(List<string> segments, int languageId)
+        {
+            Segments = segments;
+            LanguageId = languageId;
+            Language = WhisperLanguage.GetLanguageString(languageId);
+            
+            // generate full string based on segments
+            var builder = new StringBuilder();
+            foreach (var seg in segments)
+            {
+                builder.Append(seg);
+            }
+            Result = builder.ToString();
+        }
+    }
+
+    public class WhisperSegment
+    {
+        public readonly int Index;
+        public readonly string Text;
+        public readonly ulong Start;
+        public readonly ulong Stop;
+
+        public WhisperSegment(int index, string text, ulong start, ulong stop)
+        {
+            Index = index;
+            Text = text;
+            Start = start;
+            Stop = stop;
+        }
+    }
+}

--- a/Packages/com.whisper.unity/Runtime/WhisperResult.cs.meta
+++ b/Packages/com.whisper.unity/Runtime/WhisperResult.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 87483829538049baafd3e9636f2cea7e
+timeCreated: 1682113203

--- a/Packages/com.whisper.unity/Runtime/WhisperWrapper.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperWrapper.cs
@@ -101,14 +101,18 @@ namespace Whisper
                 var n = WhisperNative.whisper_full_n_segments(_whisperCtx);
                 Debug.Log($"Number of text segments: {n}");
 
-                var list = new List<string>();
+                var list = new List<WhisperSegment>();
                 for (var i = 0; i < n; ++i) {
                     Debug.Log($"Requesting text segment {i}...");
                     var textPtr = WhisperNative.whisper_full_get_segment_text(_whisperCtx, i);
                     var text = Marshal.PtrToStringAnsi(textPtr);
                     Debug.Log(text);
+                    
+                    var start = WhisperNative.whisper_full_get_segment_t0(_whisperCtx, i);
+                    var end = WhisperNative.whisper_full_get_segment_t1(_whisperCtx, i);
+                    var segment = new WhisperSegment(i, text, start, end);
 
-                    list.Add(text);
+                    list.Add(segment);
                 }
 
                 var langId = WhisperNative.whisper_full_lang_id(_whisperCtx);
@@ -163,9 +167,9 @@ namespace Whisper
                 var textPtr = WhisperNative.whisper_full_get_segment_text(_whisperCtx, i);
                 var text = Marshal.PtrToStringAnsi(textPtr);
                 var start = WhisperNative.whisper_full_get_segment_t0(_whisperCtx, i);
-                var stop = WhisperNative.whisper_full_get_segment_t1(_whisperCtx, i);
+                var end = WhisperNative.whisper_full_get_segment_t1(_whisperCtx, i);
                 
-                var segment = new WhisperSegment(i, text, start, stop);
+                var segment = new WhisperSegment(i, text, start, end);
                 OnNewSegment?.Invoke(segment);
             }
         }

--- a/Packages/com.whisper.unity/Runtime/WhisperWrapper.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperWrapper.cs
@@ -159,12 +159,12 @@ namespace Whisper
             var s0 = nSegments - nNew;
             for (var i = s0; i < nSegments; i++)
             {
-                // raise event with new text segment
+                // get segment text and timestamps
                 var textPtr = WhisperNative.whisper_full_get_segment_text(_whisperCtx, i);
                 var text = Marshal.PtrToStringAnsi(textPtr);
                 var start = WhisperNative.whisper_full_get_segment_t0(_whisperCtx, i);
                 var stop = WhisperNative.whisper_full_get_segment_t1(_whisperCtx, i);
-
+                
                 var segment = new WhisperSegment(i, text, start, stop);
                 OnNewSegment?.Invoke(segment);
             }


### PR DESCRIPTION
Towards #9 

Add support for segments timestamps. Updated `AudioClipDemo` to showcase that. Microphone demo doesn't support it yet, will probably refactor text output functions to make them reusable.

<img width="956" alt="Снимок экрана 2023-04-22 в 12 22 40" src="https://user-images.githubusercontent.com/6161335/233778816-92ac7f5a-03e0-4961-8726-ba1b3db0ffb9.png">
