### PR TITLE
CI for build whisper.cpp libraries

### DIFF
--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -32,3 +32,12 @@ jobs:
           name: windows
           path: ${{ github.workspace }}/whisper-unity/Packages/com.whisper.unity/Plugins/Windows/
           if-no-files-found: error
+  build-linux:
+    name: Build for Linux
+    runs-on: ubuntu-latest
+    container: ubuntu:18.04
+    steps:
+      - name: Get glibc
+        run: ldd --version
+        
+          

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -153,6 +153,7 @@ jobs:
       - name: Install Android NDK
         run: |
           sdkmanager --install "build-tools;31.0.0"
+          sdkmanager --install "cmake;3.22.1"
           sdkmanager --install "ndk;25.0.8775105"
           
       - name: Check 

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -133,5 +133,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ios
-          path: ${{ github.workspace }}/whisper-unity/Packages/com.whisper.unity/Plugins/iOS/
+          path: ${{ github.workspace }}/whisper-cpp/build/libwhisper.dylib
           if-no-files-found: error

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -150,9 +150,9 @@ jobs:
 
       - name: Install Android NDK
         run: |
-          sdkmanager --install "build-tools;31.0.0"
+          sdkmanager --install "build-tools;33.0.2"
           sdkmanager --install "cmake;3.22.1"
-          sdkmanager --install "ndk;25.0.8775105"
+          sdkmanager --install "ndk;25.1.8937393"
           
       - name: Clone whisper.unity
         uses: actions/checkout@v3
@@ -169,7 +169,7 @@ jobs:
       - name: Run build script
         run: |
           cd whisper-unity
-          sh build_cpp.sh ../whisper-cpp/ android $ANDROID_HOME/ndk/25.0.8775105/build/cmake/android.toolchain.cmake
+          sh build_cpp.sh ../whisper-cpp/ android $ANDROID_HOME/ndk/25.1.8937393/build/cmake/android.toolchain.cmake
           
       - name: Upload results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -34,6 +34,8 @@ jobs:
         run: |
           cd whisper-unity
           .\build_cpp.bat ..\whisper-cpp\
+          cd ${{ github.workspace }}/whisper-cpp/build/Release
+          ren whisper.dll libwhisper.dll
           
       - name: Upload results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -14,7 +14,6 @@ jobs:
   build-windows:
     name: Build for Windows (x86_64)
     runs-on: windows-latest
-    if: false
     steps:
       - name: Clone whisper.unity
         uses: actions/checkout@v3
@@ -47,7 +46,6 @@ jobs:
     name: Build for Linux (Ubuntu 18.04 x86_64)
     runs-on: ubuntu-latest
     container: ubuntu:18.04
-    if: false
     steps:
       - name: Clone whisper.unity
         uses: actions/checkout@v3
@@ -82,7 +80,6 @@ jobs:
   build-macos:
     name: Build for MacOS (ARM, x86_64)
     runs-on: macOS-latest
-    if: false
     steps:
       - name: Clone whisper.unity
         uses: actions/checkout@v3
@@ -111,7 +108,6 @@ jobs:
   build-ios:
     name: Build for iOS
     runs-on: macOS-latest
-    if: false
     steps:
       - name: Clone whisper.unity
         uses: actions/checkout@v3
@@ -176,6 +172,6 @@ jobs:
       - name: Upload results
         uses: actions/upload-artifact@v3
         with:
-          name: ios
+          name: android
           path: ${{ github.workspace }}/whisper-cpp/build/libwhisper.a
           if-no-files-found: error

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: windows
-          path: ${{ github.workspace }}/whisper-unity/Packages/com.whisper.unity/Plugins/Windows/
+          path: ${{ github.workspace }}/whisper-cpp/build/libwhisper.dll
           if-no-files-found: error
           
   build-linux:
@@ -76,7 +76,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: linux
-          path: ${{ github.workspace }}/whisper-unity/Packages/com.whisper.unity/Plugins/Linux/
+          path: ${{ github.workspace }}/whisper-cpp/build/libwhisper.so
           if-no-files-found: error
           
   build-macos:
@@ -105,12 +105,13 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: macos
-          path: ${{ github.workspace }}/whisper-unity/Packages/com.whisper.unity/Plugins/MacOS/
+          path: ${{ github.workspace }}/whisper-cpp/build/libwhisper.dylib
           if-no-files-found: error
           
   build-ios:
     name: Build for iOS
     runs-on: macOS-latest
+    if: false
     steps:
       - name: Clone whisper.unity
         uses: actions/checkout@v3
@@ -135,3 +136,24 @@ jobs:
           name: ios
           path: ${{ github.workspace }}/whisper-cpp/build/libwhisper.a
           if-no-files-found: error
+
+  build-android:
+    name: Build for Android (arm64-v8a)
+    runs-on: ubuntu-latest
+    steps:          
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: zulu
+          java-version: 17
+      
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
+      - name: Install Android NDK
+        run: |
+          sdkmanager --install "build-tools;31.0.0"
+          sdkmanager --install "ndk;25.0.8775105"
+          
+      - name: Check 
+        run: echo $ANDROID_SDK_PATH      

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -137,7 +137,7 @@ jobs:
 
   build-android:
     name: Build for Android (arm64-v8a)
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     steps:          
       - name: Install Java
         uses: actions/setup-java@v3

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -156,4 +156,4 @@ jobs:
           sdkmanager --install "ndk;25.0.8775105"
           
       - name: Check 
-        run: find $ANDROID_SDK_PATH -type f -print      
+        run: find $ANDROID_HOME -type f -print      

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -156,5 +156,26 @@ jobs:
           sdkmanager --install "cmake;3.22.1"
           sdkmanager --install "ndk;25.0.8775105"
           
-      - name: Check 
-        run: find $ANDROID_HOME/../ -type f -print      
+      - name: Clone whisper.unity
+        uses: actions/checkout@v3
+        with:
+          path: whisper-unity
+          
+      - name: Clone whisper.cpp
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.inputs.whisper_cpp_repo }}
+          ref: ${{ github.event.inputs.whisper_cpp_repo_ref }}
+          path: whisper-cpp
+          
+      - name: Run build script
+        run: |
+          cd whisper-unity
+          sh build_cpp.sh ../whisper-cpp/ android $ANDROID_HOME/ndk/25.0.8775105/build/cmake/android.toolchain.cmake
+          
+      - name: Upload results
+        uses: actions/upload-artifact@v3
+        with:
+          name: ios
+          path: ${{ github.workspace }}/whisper-cpp/build/libwhisper.a
+          if-no-files-found: error

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -156,4 +156,4 @@ jobs:
           sdkmanager --install "ndk;25.0.8775105"
           
       - name: Check 
-        run: find $ANDROID_HOME -type f -print      
+        run: find $ANDROID_HOME/../ -type f -print      

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -12,8 +12,9 @@ on:
         default: 'v1.2.1'
 jobs:
   build-windows:
-    name: Build for Windows x64
+    name: Build for Windows x86_64
     runs-on: windows-latest
+    if: false
     steps:
       - name: Clone whisper.unity
         uses: actions/checkout@v3
@@ -43,9 +44,10 @@ jobs:
           if-no-files-found: error
           
   build-linux:
-    name: Build for Linux x64 (Ubuntu 18.04)
+    name: Build for Linux x86_64 (Ubuntu 18.04)
     runs-on: ubuntu-latest
     container: ubuntu:18.04
+    if: false
     steps:
       - name: Clone whisper.unity
         uses: actions/checkout@v3
@@ -75,4 +77,32 @@ jobs:
         with:
           name: linux
           path: ${{ github.workspace }}/whisper-unity/Packages/com.whisper.unity/Plugins/Linux/
+          if-no-files-found: error
+          
+  build-macos:
+    name: Build for MacOS (ARM, x86_64)
+    runs-on: macOS-latest
+    steps:
+      - name: Clone whisper.unity
+        uses: actions/checkout@v3
+        with:
+          path: whisper-unity
+          
+      - name: Clone whisper.cpp
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.inputs.whisper_cpp_repo }}
+          ref: ${{ github.event.inputs.whisper_cpp_repo_ref }}
+          path: whisper-cpp
+          
+      - name: Run build script
+        run: |
+          cd whisper-unity
+          sh build_cpp.sh ../whisper-cpp/ mac
+          
+      - name: Upload results
+        uses: actions/upload-artifact@v3
+        with:
+          name: macos
+          path: ${{ github.workspace }}/whisper-unity/Packages/com.whisper.unity/Plugins/MacOS/
           if-no-files-found: error

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -34,14 +34,14 @@ jobs:
         run: |
           cd whisper-unity
           .\build_cpp.bat ..\whisper-cpp\
-          cd ${{ github.workspace }}/whisper-cpp/build/Release
+          cd ${{ github.workspace }}\whisper-cpp\build\bin\Release
           ren whisper.dll libwhisper.dll
           
       - name: Upload results
         uses: actions/upload-artifact@v3
         with:
           name: windows
-          path: ${{ github.workspace }}/whisper-cpp/build/Release/libwhisper.dll
+          path: ${{ github.workspace }}/whisper-cpp/build/bin/Release/libwhisper.dll
           if-no-files-found: error
           
   build-linux:

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -30,4 +30,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: windows
-          path: $GITHUB_WORKSPACE/whisper-unity/Packages/com.whisper.unity/Plugins/Windows/
+          path: ${{ github.workspace }}/whisper-unity/Packages/com.whisper.unity/Plugins/Windows/
+          if-no-files-found: error

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -152,7 +152,7 @@ jobs:
         run: |
           sdkmanager --install "build-tools;33.0.2"
           sdkmanager --install "cmake;3.22.1"
-          sdkmanager --install "ndk;25.1.8937393"
+          sdkmanager --install "ndk;21.3.6528147"
           
       - name: Clone whisper.unity
         uses: actions/checkout@v3
@@ -169,7 +169,7 @@ jobs:
       - name: Run build script
         run: |
           cd whisper-unity
-          sh build_cpp.sh ../whisper-cpp/ android $ANDROID_HOME/ndk/25.1.8937393/build/cmake/android.toolchain.cmake
+          sh build_cpp.sh ../whisper-cpp/ android $ANDROID_HOME/ndk/21.3.6528147/build/cmake/android.toolchain.cmake
           
       - name: Upload results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -22,7 +22,7 @@ jobs:
         uses: microsoft/setup-msbuild@v1
         
       - name: Run build script
-        run: >
+        run: |
           cd whisper-unity
           .\build_cpp.bat ..\whisper-cpp\
           

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -133,5 +133,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ios
-          path: ${{ github.workspace }}/whisper-cpp/build/libwhisper.dylib
+          path: ${{ github.workspace }}/whisper-cpp/build/libwhisper.a
           if-no-files-found: error

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -32,12 +32,38 @@ jobs:
           name: windows
           path: ${{ github.workspace }}/whisper-unity/Packages/com.whisper.unity/Plugins/Windows/
           if-no-files-found: error
+          
   build-linux:
-    name: Build for Linux
+    name: Build for Linux (Ubuntu 18.04)
     runs-on: ubuntu-latest
     container: ubuntu:18.04
     steps:
-      - name: Get glibc
-        run: ldd --version
-        
+      - name: Clone whisper.unity
+        uses: actions/checkout@v3
+        with:
+          path: whisper-unity
           
+      - name: Clone whisper.cpp
+        uses: actions/checkout@v3
+        with:
+          repository: ggerganov/whisper.cpp
+          ref: v1.2.1
+          path: whisper-cpp
+        
+      - name: Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install build-essential
+          sudo apt-get install cmake
+          
+      - name: Run build script
+        run: |
+          cd whisper-unity
+          sh build_cpp_linux.sh ../whisper-cpp/
+          
+      - name: Upload results
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux
+          path: ${{ github.workspace }}/whisper-unity/Packages/com.whisper.unity/Plugins/Linux/
+          if-no-files-found: error

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -1,6 +1,15 @@
 name: Build C++
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      whisper_cpp_repo:
+        description: 'whisper.cpp repo link'
+        required: true
+        default: 'ggerganov/whisper.cpp'
+      whisper_cpp_repo_ref:
+        description: 'Tag, branch or commit'
+        required: true
+        default: 'v1.2.1'
 jobs:
   build-windows:
     name: Build for Windows x64
@@ -14,8 +23,8 @@ jobs:
       - name: Clone whisper.cpp
         uses: actions/checkout@v3
         with:
-          repository: ggerganov/whisper.cpp
-          ref: v1.2.1
+          repository: ${{ github.event.inputs.whisper_cpp_repo }}
+          ref: ${{ github.event.inputs.whisper_cpp_repo_ref }}
           path: whisper-cpp
           
       - name: Add msbuild to PATH
@@ -34,7 +43,7 @@ jobs:
           if-no-files-found: error
           
   build-linux:
-    name: Build for Linux (Ubuntu 18.04)
+    name: Build for Linux x64 (Ubuntu 18.04)
     runs-on: ubuntu-latest
     container: ubuntu:18.04
     steps:
@@ -46,8 +55,8 @@ jobs:
       - name: Clone whisper.cpp
         uses: actions/checkout@v3
         with:
-          repository: ggerganov/whisper.cpp
-          ref: v1.2.1
+          repository: ${{ github.event.inputs.whisper_cpp_repo }}
+          ref: ${{ github.event.inputs.whisper_cpp_repo_ref }}
           path: whisper-cpp
         
       - name: Dependencies

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -137,7 +137,7 @@ jobs:
 
   build-android:
     name: Build for Android (arm64-v8a)
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     steps:          
       - name: Install Java
         uses: actions/setup-java@v3

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -52,9 +52,9 @@ jobs:
         
       - name: Dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install build-essential
-          sudo apt-get install cmake
+          apt-get update
+          apt-get install build-essential
+          apt-get install cmake
           
       - name: Run build script
         run: |

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -156,4 +156,4 @@ jobs:
           sdkmanager --install "ndk;25.0.8775105"
           
       - name: Check 
-        run: echo $ANDROID_SDK_PATH      
+        run: find $ANDROID_SDK_PATH -type f -print      

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -82,6 +82,7 @@ jobs:
   build-macos:
     name: Build for MacOS (ARM, x86_64)
     runs-on: macOS-latest
+    if: false
     steps:
       - name: Clone whisper.unity
         uses: actions/checkout@v3
@@ -110,7 +111,6 @@ jobs:
   build-ios:
     name: Build for iOS
     runs-on: macOS-latest
-    if: false
     steps:
       - name: Clone whisper.unity
         uses: actions/checkout@v3

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -12,7 +12,7 @@ on:
         default: 'v1.2.1'
 jobs:
   build-windows:
-    name: Build for Windows x86_64
+    name: Build for Windows (x86_64)
     runs-on: windows-latest
     if: false
     steps:
@@ -44,7 +44,7 @@ jobs:
           if-no-files-found: error
           
   build-linux:
-    name: Build for Linux x86_64 (Ubuntu 18.04)
+    name: Build for Linux (Ubuntu 18.04 x86_64)
     runs-on: ubuntu-latest
     container: ubuntu:18.04
     if: false
@@ -105,4 +105,33 @@ jobs:
         with:
           name: macos
           path: ${{ github.workspace }}/whisper-unity/Packages/com.whisper.unity/Plugins/MacOS/
+          if-no-files-found: error
+          
+  build-ios:
+    name: Build for iOS
+    runs-on: macOS-latest
+    if: false
+    steps:
+      - name: Clone whisper.unity
+        uses: actions/checkout@v3
+        with:
+          path: whisper-unity
+          
+      - name: Clone whisper.cpp
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.inputs.whisper_cpp_repo }}
+          ref: ${{ github.event.inputs.whisper_cpp_repo_ref }}
+          path: whisper-cpp
+          
+      - name: Run build script
+        run: |
+          cd whisper-unity
+          sh build_cpp.sh ../whisper-cpp/ ios
+          
+      - name: Upload results
+        uses: actions/upload-artifact@v3
+        with:
+          name: ios
+          path: ${{ github.workspace }}/whisper-unity/Packages/com.whisper.unity/Plugins/iOS/
           if-no-files-found: error

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Dependencies
         run: |
           apt-get update
-          apt-get install build-essential
-          apt-get install cmake
+          apt-get install -y build-essential
+          apt-get install -y cmake
           
       - name: Run build script
         run: |

--- a/.github/workflows/build_cpp.yml
+++ b/.github/workflows/build_cpp.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: windows
-          path: ${{ github.workspace }}/whisper-cpp/build/libwhisper.dll
+          path: ${{ github.workspace }}/whisper-cpp/build/Release/libwhisper.dll
           if-no-files-found: error
           
   build-linux:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ You can download model weights [from here](https://huggingface.co/ggerganov/whis
 For more information about models differences and formats read [whisper.cpp readme](https://github.com/ggerganov/whisper.cpp#ggml-format) and [OpenAI readme](https://github.com/openai/whisper#available-models-and-languages).
 
 ## Compiling C++ libraries from source
-This project comes with prebuild libraries of whisper.cpp for all supported platforms. In case you want to build libraries yourself:
+This project comes with prebuild libraries of whisper.cpp for all supported platforms. You can rebuild them from source using Github Actions. To do that make fork of this repo and go into `Actions => Build C++ => Run workflow`.  After pipeline completed, download compiled libraries in artifacts tab.
+
+In case you want to build libraries on your machine:
 1. Clone the original [whisper.cpp](https://github.com/ggerganov/whisper.cpp) repository
 2. Checkout tag [v1.2.1](https://github.com/ggerganov/whisper.cpp/releases/tag/v1.2.1). Other versions might not work with this Unity bindings.
 3. Open whisper.unity folder with command line

--- a/build_cpp.sh
+++ b/build_cpp.sh
@@ -16,7 +16,7 @@ build_mac() {
   clean_build
   echo "Starting building for Mac..."
 
-  cmake -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" ../
+  cmake -DCMAKE_OSX_ARCHITECTURES="x86_64" ../
   make
 
   echo "Build for Mac complete!"

--- a/build_cpp.sh
+++ b/build_cpp.sh
@@ -16,7 +16,7 @@ build_mac() {
   clean_build
   echo "Starting building for Mac..."
 
-  cmake -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DCMAKE_SYSTEM_PROCESSOR=arm ../
+  cmake -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DWHISPER_NO_AVX=ON -DWHISPER_NO_AVX2=ON -DWHISPER_NO_FMA=ON ../
   make
 
   echo "Build for Mac complete!"

--- a/build_cpp.sh
+++ b/build_cpp.sh
@@ -16,7 +16,7 @@ build_mac() {
   clean_build
   echo "Starting building for Mac..."
 
-  cmake -DCMAKE_OSX_ARCHITECTURES="x86_64" -DCMAKE_SYSTEM_PROCESSOR=arm64 ../
+  cmake -DCMAKE_OSX_ARCHITECTURES="x86_64" -DWHISPER_NO_AVX=True -DWHISPER_NO_AVX2=True -WHISPER_NO_FMA=True ../
   make
 
   echo "Build for Mac complete!"

--- a/build_cpp.sh
+++ b/build_cpp.sh
@@ -16,7 +16,7 @@ build_mac() {
   clean_build
   echo "Starting building for Mac..."
 
-  cmake -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DCMAKE_BUILD_TYPE=Debug ../
+  cmake -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DCMAKE_SYSTEM_PROCESSOR=arm ../
   make
 
   echo "Build for Mac complete!"

--- a/build_cpp.sh
+++ b/build_cpp.sh
@@ -16,7 +16,7 @@ build_mac() {
   clean_build
   echo "Starting building for Mac..."
 
-  cmake -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DWHISPER_NO_AVX=ON -DWHISPER_NO_AVX2=ON -DWHISPER_NO_FMA=ON ../
+  cmake -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" ../
   make
 
   echo "Build for Mac complete!"

--- a/build_cpp.sh
+++ b/build_cpp.sh
@@ -16,7 +16,7 @@ build_mac() {
   clean_build
   echo "Starting building for Mac..."
 
-  cmake -DCMAKE_OSX_ARCHITECTURES="x86_64" -DWHISPER_NO_AVX=True -DWHISPER_NO_AVX2=True -WHISPER_NO_FMA=True ../
+  cmake -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DCMAKE_BUILD_TYPE=Debug ../
   make
 
   echo "Build for Mac complete!"

--- a/build_cpp.sh
+++ b/build_cpp.sh
@@ -16,7 +16,7 @@ build_mac() {
   clean_build
   echo "Starting building for Mac..."
 
-  cmake -DCMAKE_OSX_ARCHITECTURES="x86_64" ../
+  cmake -DCMAKE_OSX_ARCHITECTURES="x86_64" -DCMAKE_SYSTEM_PROCESSOR=arm64 ../
   make
 
   echo "Build for Mac complete!"


### PR DESCRIPTION
Added new Github Action for building native C++ libraries of whisper.cpp. It can be run manually by creating your fork and going into `Actions => Build C++ => Run workflow`. After pipeline completed, download compiled libraries in artifacts tab.

You can choose different whisper.cpp repo and tag/branch that you want to build. By default it's using [ggerganov/whisper.cpp](https://github.com/ggerganov/whisper.cpp) and [v1.2.1](https://github.com/ggerganov/whisper.cpp/releases/tag/v1.2.1) tag.

Some remarks for each platform:
- **Windows x86_64** - works great, compiled by msbuild
- **Linux x86_64** - compiled in Ubuntu 18.04 docker. This should work on Ubuntu 18.04 and newer
- **MacOS** - ARM build works great, but x86_64 build crashes. I suspect there is a bug in original cmake. Should be fixed by new version of whisper.cpp
- **iOS Device/Simulator** - works great, no changes
- **Android ARM64**  - works, but need very specific version of NDK. Others fail to compile in Unity.

<img width="1512" alt="Снимок экрана 2023-06-04 в 11 35 52" src="https://github.com/Macoron/whisper.unity/assets/6161335/28ce4803-078d-464b-8559-94e3592098aa">

Except MacOS x86_64 all binaries compiled correctly and work on my machines.

Fun Fact: gcc build for Ubuntu works up to 20% faster than Windows  msbuild on same hardware.
