### PR TITLE
Endless loop microphone and memory leak fix

### DIFF
--- a/Assets/Samples/2 - Microphone/2 - Microphone.unity
+++ b/Assets/Samples/2 - Microphone/2 - Microphone.unity
@@ -1092,7 +1092,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d9370225a2ca94276b870d5f87b0db55, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  logLevel: 0
+  logLevel: 1
   modelPath: Whisper/ggml-tiny.bin
   isModelPathInStreamingAssets: 1
   initOnAwake: 1
@@ -3111,7 +3111,7 @@ MonoBehaviour:
   vadUpdateRateSec: 0.1
   vadContextSec: 30
   vadLastSec: 1.25
-  vadThd: 1.2
+  vadThd: 1
   vadFreqThd: 100
   vadIndicatorImage: {fileID: 1756544758}
   vadStop: 0

--- a/Assets/Samples/2 - Microphone/2 - Microphone.unity
+++ b/Assets/Samples/2 - Microphone/2 - Microphone.unity
@@ -1092,7 +1092,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d9370225a2ca94276b870d5f87b0db55, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  logLevel: 1
+  logLevel: 0
   modelPath: Whisper/ggml-tiny.bin
   isModelPathInStreamingAssets: 1
   initOnAwake: 1
@@ -1360,7 +1360,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.000030517578, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &720715772
@@ -3102,10 +3102,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3bc03a4c19604ea394e364f8fc632928, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  loop: 0
   maxLengthSec: 30
   frequency: 16000
   chunksLengthSec: 0.5
-  echo: 0
+  echo: 1
   useVad: 1
   vadUpdateRateSec: 0.1
   vadContextSec: 30
@@ -3115,9 +3116,9 @@ MonoBehaviour:
   vadIndicatorImage: {fileID: 1756544758}
   vadStop: 0
   dropVadPart: 1
-  vadStopTime: 1.5
+  vadStopTime: 3
   microphoneDropdown: {fileID: 948466958}
-  microphoneDefaultLabel: Default mic
+  microphoneDefaultLabel: Default microphone
 --- !u!1 &1345287211
 GameObject:
   m_ObjectHideFlags: 0
@@ -3201,7 +3202,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 967652833}
   m_HandleRect: {fileID: 967652832}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -4167,7 +4168,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0.000030517578, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1603953686
@@ -4253,7 +4254,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.00012207031, y: 0}
+  m_AnchoredPosition: {x: -0.00024414062, y: 0}
   m_SizeDelta: {x: 55.6282, y: 55.6282}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &1756544758

--- a/Assets/Samples/2 - Microphone/2 - Microphone.unity
+++ b/Assets/Samples/2 - Microphone/2 - Microphone.unity
@@ -3102,8 +3102,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3bc03a4c19604ea394e364f8fc632928, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  loop: 0
-  maxLengthSec: 30
+  loop: 1
+  maxLengthSec: 60
   frequency: 16000
   chunksLengthSec: 0.5
   echo: 1
@@ -3111,7 +3111,7 @@ MonoBehaviour:
   vadUpdateRateSec: 0.1
   vadContextSec: 30
   vadLastSec: 1.25
-  vadThd: 0.6
+  vadThd: 1.2
   vadFreqThd: 100
   vadIndicatorImage: {fileID: 1756544758}
   vadStop: 0

--- a/Assets/Samples/2 - Microphone/MicrophoneDemo.cs
+++ b/Assets/Samples/2 - Microphone/MicrophoneDemo.cs
@@ -67,7 +67,7 @@ namespace Whisper.Samples
             }
         }
         
-        private async void OnRecordStop(float[] data, int frequency, int channels, float length)
+        private async void OnRecordStop(AudioChunk recordedAudio)
         {
             buttonText.text = "Record";
             _buffer = "";
@@ -75,12 +75,12 @@ namespace Whisper.Samples
             var sw = new Stopwatch();
             sw.Start();
             
-            var res = await whisper.GetTextAsync(data, frequency, channels);
+            var res = await whisper.GetTextAsync(recordedAudio.Data, recordedAudio.Frequency, recordedAudio.Channels);
             if (res == null || !outputText) 
                 return;
 
             var time = sw.ElapsedMilliseconds;
-            var rate = length / (time * 0.001f);
+            var rate = recordedAudio.Length / (time * 0.001f);
             timeText.text = $"Time: {time} ms\nRate: {rate:F1}x";
 
             var text = res.Result;

--- a/Assets/Samples/5 - Streaming/5 - Streaming.unity
+++ b/Assets/Samples/5 - Streaming/5 - Streaming.unity
@@ -550,7 +550,7 @@ MonoBehaviour:
   modelPath: Whisper/ggml-tiny.bin
   isModelPathInStreamingAssets: 1
   initOnAwake: 1
-  language: ru
+  language: en
   translateToEnglish: 0
   strategy: 0
   noContext: 1
@@ -1874,8 +1874,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3bc03a4c19604ea394e364f8fc632928, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  loop: 1
   maxLengthSec: 60
+  loop: 1
   frequency: 16000
   chunksLengthSec: 0.5
   echo: 0
@@ -1883,7 +1883,7 @@ MonoBehaviour:
   vadUpdateRateSec: 0.1
   vadContextSec: 30
   vadLastSec: 1.25
-  vadThd: 1.2
+  vadThd: 1
   vadFreqThd: 100
   vadIndicatorImage: {fileID: 1303962929}
   vadStop: 0

--- a/Assets/Samples/5 - Streaming/5 - Streaming.unity
+++ b/Assets/Samples/5 - Streaming/5 - Streaming.unity
@@ -550,7 +550,7 @@ MonoBehaviour:
   modelPath: Whisper/ggml-tiny.bin
   isModelPathInStreamingAssets: 1
   initOnAwake: 1
-  language: en
+  language: ru
   translateToEnglish: 0
   strategy: 0
   noContext: 1
@@ -1874,22 +1874,23 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 3bc03a4c19604ea394e364f8fc632928, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  maxLengthSec: 240
+  loop: 1
+  maxLengthSec: 60
   frequency: 16000
-  chunksLengthSec: 0.2
-  echo: 1
+  chunksLengthSec: 0.5
+  echo: 0
   useVad: 1
   vadUpdateRateSec: 0.1
   vadContextSec: 30
   vadLastSec: 1.25
-  vadThd: 0.6
+  vadThd: 1.2
   vadFreqThd: 100
   vadIndicatorImage: {fileID: 1303962929}
   vadStop: 0
   dropVadPart: 1
   vadStopTime: 3
   microphoneDropdown: {fileID: 948466958}
-  microphoneDefaultLabel: Default mic
+  microphoneDefaultLabel: Default microphone
 --- !u!114 &1337591124
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1991,7 +1992,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 967652833}
   m_HandleRect: {fileID: 967652832}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:

--- a/Assets/Samples/5 - Streaming/StreamingSampleMic.cs
+++ b/Assets/Samples/5 - Streaming/StreamingSampleMic.cs
@@ -44,7 +44,7 @@ namespace Whisper.Samples
             buttonText.text = microphoneRecord.IsRecording ? "Stop" : "Record";
         }
     
-        private void OnRecordStop(float[] data, int frequency, int channels, float length)
+        private void OnRecordStop(AudioChunk recordedAudio)
         {
             buttonText.text = "Record";
         }

--- a/Packages/com.whisper.unity/Runtime/Utils/MicrophoneRecord.cs
+++ b/Packages/com.whisper.unity/Runtime/Utils/MicrophoneRecord.cs
@@ -152,12 +152,11 @@ namespace Whisper.Utils
             _lastMicPos = micPos;
 
             // still recording - update chunks and vad
-            var buffer = GetMicBuffer();
-            //UpdateChunks();
+            UpdateChunks(micPos);
             UpdateVad(micPos);
         }
         
-        private void UpdateChunks()
+        private void UpdateChunks(int micPos)
         {
             // is anyone even subscribe to do this?
             if (OnChunkReady == null)
@@ -168,8 +167,7 @@ namespace Whisper.Utils
                 return;
             
             // get current chunk length
-            var micPos = Microphone.GetPosition(RecordStartMicDevice);
-            var chunk = micPos - _lastChunkPos;
+            var chunk = GetMicPosDist(_lastChunkPos, micPos);
             
             // send new chunks while there has valid size
             while (chunk > _chunksLength)
@@ -187,8 +185,8 @@ namespace Whisper.Utils
                 };
                 OnChunkReady(chunkStruct);
 
-                _lastChunkPos += _chunksLength;
-                chunk = micPos - _lastChunkPos;
+                _lastChunkPos = (_lastChunkPos + _chunksLength) % ClipSamples;
+                chunk = GetMicPosDist(_lastChunkPos, micPos);
             }
         }
         

--- a/Packages/com.whisper.unity/Runtime/Utils/MicrophoneRecord.cs
+++ b/Packages/com.whisper.unity/Runtime/Utils/MicrophoneRecord.cs
@@ -272,6 +272,10 @@ namespace Whisper.Utils
             _chunksLength = (int) (_clip.frequency * _clip.channels * chunksLengthSec);
         }
 
+        /// <summary>
+        /// Stop microphone record.
+        /// </summary>
+        /// <param name="dropTimeSec">How many last recording seconds to drop.</param>
         public void StopRecord(float dropTimeSec = 0f)
         {
             if (!IsRecording)
@@ -319,7 +323,7 @@ namespace Whisper.Utils
         {
             var pos = Microphone.GetPosition(RecordStartMicDevice);
             
-            // looks like we just started recording and drop it immediately
+            // looks like we just started recording and stopped it immediately
             // nothing was actually recorded
             if (pos == 0 && !_madeLoopLap)
                 return Array.Empty<float>();
@@ -330,7 +334,8 @@ namespace Whisper.Utils
             var dropTimeSamples = (int) (_clip.frequency * _clip.channels * dropTimeSec);
             len = Math.Max(0, len - dropTimeSamples);
             
-            // get actual float buffer from circular buffer audio clip
+            // get last len samples from recorded audio
+            // offset used to get audio from previous circular buffer lap
             var data = new float[len];
             var offset = _madeLoopLap ? pos : 0;
             _clip.GetData(data, offset);

--- a/Packages/com.whisper.unity/Runtime/Utils/MicrophoneRecord.cs
+++ b/Packages/com.whisper.unity/Runtime/Utils/MicrophoneRecord.cs
@@ -277,6 +277,7 @@ namespace Whisper.Utils
             if (!IsRecording)
                 return;
             
+            // get all data from mic audio clip
             var data = GetMicBuffer(dropTimeSec);
             var finalAudio = new AudioChunk()
             {
@@ -287,10 +288,10 @@ namespace Whisper.Utils
                 Length = (float) data.Length / (_clip.frequency * _clip.channels)
             };
             
+            // stop mic audio recording
             Microphone.End(RecordStartMicDevice);
             IsRecording = false;
             Destroy(_clip);
-            
             LogUtils.Verbose($"Stopped microphone recording. Final audio length " +
                              $"{finalAudio.Length} ({finalAudio.Data.Length} samples)");
 
@@ -307,10 +308,10 @@ namespace Whisper.Utils
                 var echoClip = AudioClip.Create("echo", data.Length,
                     _clip.channels, _clip.frequency, false);
                 echoClip.SetData(data, 0);
-                AudioSource.PlayClipAtPoint(echoClip, Vector3.zero);
+                PlayAudioAndDestroy.Play(echoClip, Vector3.zero);
             }
 
-            
+            // finally, fire event
             OnRecordStop?.Invoke(finalAudio);
         }
 

--- a/Packages/com.whisper.unity/Runtime/Utils/MicrophoneRecord.cs
+++ b/Packages/com.whisper.unity/Runtime/Utils/MicrophoneRecord.cs
@@ -29,9 +29,10 @@ namespace Whisper.Utils
     /// </summary>
     public class MicrophoneRecord : MonoBehaviour
     {
-        public bool loop;
         [Tooltip("Max length of recorded audio from microphone in seconds")]
         public int maxLengthSec = 60;
+        [Tooltip("After reaching max length microphone record will continue")]
+        public bool loop;
         [Tooltip("Microphone sample rate")]
         public int frequency = 16000;
         [Tooltip("Length of audio chunks in seconds, useful for streaming")]
@@ -49,7 +50,7 @@ namespace Whisper.Utils
         [Tooltip("Window size where VAD tries to detect speech")]
         public float vadLastSec = 1.25f;
         [Tooltip("Threshold of VAD energy activation")]
-        public float vadThd = 1.2f;
+        public float vadThd = 1.0f;
         [Tooltip("Threshold of VAD filter frequency")]
         public float vadFreqThd = 100.0f;
         [Tooltip("Optional indicator that changes color when speech detected")]

--- a/Packages/com.whisper.unity/Runtime/Utils/PlayAudioAndDestroy.cs
+++ b/Packages/com.whisper.unity/Runtime/Utils/PlayAudioAndDestroy.cs
@@ -1,0 +1,46 @@
+using System;
+using UnityEngine;
+
+namespace Whisper.Utils
+{
+    /// <summary>
+    /// Plays audio once and destroy itself and audio clip.
+    /// </summary>
+    public class PlayAudioAndDestroy : MonoBehaviour
+    {
+        private AudioSource _source;
+
+        private void Update()
+        {
+            if (!_source)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            if (!_source.isPlaying)
+            {
+                if (_source.clip)
+                    Destroy(_source.clip);
+                Destroy(gameObject);
+            }
+        }
+
+        /// <summary>
+        /// Play audio clip once and destroy it.
+        /// </summary>
+        public static void Play(AudioClip clip, Vector3 position, float volume = 1f)
+        {
+            var go = new GameObject("One shot audio");
+            go.transform.position = position;
+            var source = go.AddComponent<AudioSource>();
+            source.clip = clip;
+            source.spatialBlend = 1.0f;
+            source.volume = volume;
+            source.Play();
+
+            var comp = go.AddComponent<PlayAudioAndDestroy>();
+            comp._source = source;
+        }
+    }
+}

--- a/Packages/com.whisper.unity/Runtime/Utils/PlayAudioAndDestroy.cs.meta
+++ b/Packages/com.whisper.unity/Runtime/Utils/PlayAudioAndDestroy.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6af16c8293094d35aa4c385e8b5f479b
+timeCreated: 1693782001

--- a/Packages/com.whisper.unity/Runtime/WhisperStream.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperStream.cs
@@ -361,7 +361,7 @@ namespace Whisper
             AddToStream(chunk);
         }
         
-        private void MicrophoneOnRecordStop(float[] data, int frequency, int channels, float length)
+        private void MicrophoneOnRecordStop(AudioChunk recordedAudio)
         {
             StopStream();
         }


### PR DESCRIPTION
Towards #46

Add a new loop mode for microphone. It creates a new endless non-stopping stream using Unity build-in circular microphone loop. This is very useful for whisper streaming transcription. To activate it -  set `Loop` in `MicrophoneRecord` to "true".

Other minor changes:

- Fixed memory leak caused by microphone restart
- `OnRecordStop` now returns `AudioChunk` as a parameter. Update your code if you subscribed to it.
- Changed default VAD Thd to 1.0. It should work better for noisy mics.