### PR TITLE
Add visionOS support

### DIFF
--- a/Packages/com.whisper.unity/Plugins/iOS/libwhisper.a.meta
+++ b/Packages/com.whisper.unity/Plugins/iOS/libwhisper.a.meta
@@ -20,6 +20,7 @@ PluginImporter:
         Exclude Editor: 1
         Exclude Linux64: 1
         Exclude OSXUniversal: 1
+        Exclude VisionOS: 0
         Exclude WebGL: 1
         Exclude Win: 1
         Exclude Win64: 1
@@ -29,6 +30,7 @@ PluginImporter:
     second:
       enabled: 0
       settings:
+        AndroidSharedLibraryType: Executable
         CPU: ARMv7
   - first:
       Any: 
@@ -67,6 +69,15 @@ PluginImporter:
       enabled: 0
       settings:
         CPU: x86_64
+  - first:
+      VisionOS: VisionOS
+    second:
+      enabled: 1
+      settings:
+        AddToEmbeddedBinaries: false
+        CPU: ARM64
+        CompileFlags: 
+        FrameworkDependencies: 
   - first:
       iPhone: iOS
     second:

--- a/Packages/com.whisper.unity/Runtime/Native/WhisperNative.cs
+++ b/Packages/com.whisper.unity/Runtime/Native/WhisperNative.cs
@@ -11,7 +11,7 @@ namespace Whisper.Native
     /// </summary>
     public static unsafe class WhisperNative
     {
-#if (UNITY_IOS || UNITY_ANDROID) && !UNITY_EDITOR
+#if (UNITY_IOS || UNITY_VISIONOS || UNITY_ANDROID) && !UNITY_EDITOR
         private const string LibraryName = "__Internal";
 
 #elif WHISPER_CUDA


### PR DESCRIPTION
This should add Apple visionOS both for simulator and device. I don't have actual device to test myself, but simulator works fine. 