### PR TITLE
Added missing Accelerate framework

### DIFF
--- a/Packages/com.whisper.unity/Plugins/iOS/libwhisper.a.meta
+++ b/Packages/com.whisper.unity/Plugins/iOS/libwhisper.a.meta
@@ -77,7 +77,7 @@ PluginImporter:
         AddToEmbeddedBinaries: false
         CPU: ARM64
         CompileFlags: 
-        FrameworkDependencies: 
+        FrameworkDependencies: Accelerate;
   - first:
       iPhone: iOS
     second:


### PR DESCRIPTION
Title. Should fix on-device build for visionOS builds.