### PR TITLE
Use the new WHISPER_METAL_EMBED_LIBRARY flag to embed the metal lib

### DIFF
--- a/build_cpp.sh
+++ b/build_cpp.sh
@@ -36,17 +36,13 @@ build_mac_metal() {
 
   cmake -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -DWHISPER_METAL=ON \
    -DWHISPER_NO_AVX=ON -DWHISPER_NO_AVX2=ON -DWHISPER_NO_FMA=ON -DWHISPER_NO_F16C=ON \
-   -DWHISPER_BUILD_TESTS=OFF -DWHISPER_BUILD_EXAMPLES=OFF ../
+   -DWHISPER_BUILD_TESTS=OFF -DWHISPER_BUILD_EXAMPLES=OFF -DWHISPER_METAL_EMBED_LIBRARY=ON ../
   make
 
   echo "Build for Mac (Metal) complete!"
 
   artifact_path="$build_path/libwhisper.dylib"
   target_path="$unity_project/Packages/com.whisper.unity/Plugins/MacOS/libwhisper_metal.dylib"
-  cp "$artifact_path" "$target_path"
-
-  artifact_path="$build_path/bin/ggml-metal.metal"
-  target_path="$unity_project/Packages/com.whisper.unity/Plugins/MacOS/ggml-metal.metal"
   cp "$artifact_path" "$target_path"
 
   echo "Build files copied to $target_path"


### PR DESCRIPTION
Metal acceleration does not work in MacOS. The error is: https://github.com/ggerganov/llama.cpp/issues/5977

I can confirm it is working with this change.