### PR TITLE
Fixed loading model from path with non-English letters

### DIFF
--- a/Packages/com.whisper.unity/Runtime/Native/WhisperNative.cs
+++ b/Packages/com.whisper.unity/Runtime/Native/WhisperNative.cs
@@ -44,11 +44,7 @@ namespace Whisper.Native
             Environment.SetEnvironmentVariable("GGML_METAL_PATH_RESOURCES",path);
 #endif
         }
-
-        [DllImport(LibraryName)]
-        public static extern whisper_context_ptr whisper_init_from_file_with_params(string path_model,
-            WhisperNativeContextParams @params);
-
+        
         [DllImport(LibraryName)]
         public static extern whisper_context_ptr whisper_init_from_buffer_with_params(IntPtr buffer,
             UIntPtr buffer_size, WhisperNativeContextParams @params);

--- a/Packages/com.whisper.unity/Runtime/Utils/FileUtils.cs
+++ b/Packages/com.whisper.unity/Runtime/Utils/FileUtils.cs
@@ -15,6 +15,11 @@ namespace Whisper.Utils
 #if UNITY_ANDROID && !UNITY_EDITOR
             return ReadFileWebRequest(path);
 #else
+            if (!File.Exists(path))
+            {
+                LogUtils.Error($"Path {path} doesn't exist!");
+                return null;
+            }
             return File.ReadAllBytes(path);
 #endif
         }
@@ -27,6 +32,11 @@ namespace Whisper.Utils
 #if UNITY_ANDROID && !UNITY_EDITOR
             return await ReadFileWebRequestAsync(path);
 #else
+            if (!File.Exists(path))
+            {
+                LogUtils.Error($"Path {path} doesn't exist!");
+                return null;
+            }
             return await ReadAllBytesAsync(path);
 #endif
         }

--- a/Packages/com.whisper.unity/Runtime/Utils/FileUtils.cs
+++ b/Packages/com.whisper.unity/Runtime/Utils/FileUtils.cs
@@ -34,7 +34,7 @@ namespace Whisper.Utils
 #else
             if (!File.Exists(path))
             {
-                LogUtils.Error($"Path {path} doesn't exist!");
+                LogUtils.Error($"File: '{path}' doesn't exist!");
                 return null;
             }
             return await ReadAllBytesAsync(path);

--- a/Packages/com.whisper.unity/Runtime/WhisperWrapper.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperWrapper.cs
@@ -271,40 +271,11 @@ namespace Whisper
         /// <returns>Loaded whisper model. Null if loading failed.</returns>
         public static WhisperWrapper InitFromFile(string modelPath, WhisperContextParams contextParams)
         {
-#if UNITY_ANDROID && !UNITY_EDITOR
+            // load model weights
+            LogUtils.Log($"Trying to load Whisper model from {modelPath}...");
             var buffer = FileUtils.ReadFile(modelPath);
             var res = InitFromBuffer(buffer, contextParams);
             return res;
-#else
-            // load model weights
-            LogUtils.Log($"Trying to load Whisper model from {modelPath}...");
-        
-            // some sanity checks
-            if (string.IsNullOrEmpty(modelPath))
-            {
-                LogUtils.Error("Whisper model path is null or empty!");
-                return null;
-            }
-            if (!File.Exists(modelPath))
-            {
-                LogUtils.Error($"Whisper model path {modelPath} doesn't exist!");
-                return null;
-            }
-        
-            // actually loading model
-            var sw = new Stopwatch();
-            sw.Start();
-            
-            var ctx = WhisperNative.whisper_init_from_file_with_params(modelPath, contextParams.NativeParams);
-            if (ctx == IntPtr.Zero)
-            {
-                LogUtils.Error("Failed to load Whisper model!");
-                return null;
-            }
-            LogUtils.Log($"Whisper model is loaded, total time: {sw.ElapsedMilliseconds} ms.");
-            
-            return new WhisperWrapper(ctx);
-#endif
         }
 
         /// <summary>
@@ -326,14 +297,10 @@ namespace Whisper
         /// <returns>Loaded whisper model. Null if loading failed.</returns>
         public static async Task<WhisperWrapper> InitFromFileAsync(string modelPath, WhisperContextParams contextParams)
         {
-#if UNITY_ANDROID && !UNITY_EDITOR
+            LogUtils.Log($"Trying to load Whisper model from {modelPath}...");
             var buffer = await FileUtils.ReadFileAsync(modelPath);
             var res = await InitFromBufferAsync(buffer, contextParams);
             return res;
-#else
-            var asyncTask = Task.Factory.StartNew(() => InitFromFile(modelPath, contextParams));
-            return await asyncTask;          
-#endif
         }
 
         /// <summary>

--- a/Packages/com.whisper.unity/Runtime/WhisperWrapper.cs
+++ b/Packages/com.whisper.unity/Runtime/WhisperWrapper.cs
@@ -274,6 +274,9 @@ namespace Whisper
             // load model weights
             LogUtils.Log($"Trying to load Whisper model from {modelPath}...");
             var buffer = FileUtils.ReadFile(modelPath);
+            if (buffer == null)
+                return null;
+            
             var res = InitFromBuffer(buffer, contextParams);
             return res;
         }
@@ -299,6 +302,9 @@ namespace Whisper
         {
             LogUtils.Log($"Trying to load Whisper model from {modelPath}...");
             var buffer = await FileUtils.ReadFileAsync(modelPath);
+            if (buffer == null)
+                return null;
+            
             var res = await InitFromBufferAsync(buffer, contextParams);
             return res;
         }


### PR DESCRIPTION
Fix #91, fix #97.

Original `whisper_init_from_file_with_params` was causing problems for non-English paths to model weights. I replaced it with C# `File.ReadAllBytes` function which supports Unicode paths.

